### PR TITLE
ECC-11 - Email confirmation

### DIFF
--- a/app/uk/gov/hmrc/customs/managesubscription/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/config/AppConfig.scala
@@ -41,12 +41,10 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val emailServiceContext: String = config.get[String]("microservice.services.email.context")
   val emailServiceUrl: String     = s"$emailServiceBaseUrl$emailServiceContext"
 
-  val emailGyeSuccessTemplateId: String     = config.get[String]("microservice.services.email.gyeSuccessTemplateId")
-  val emailGyeNotSuccessTemplateId: String  = config.get[String]("microservice.services.email.gyeNotSuccessTemplateId")
-  val emailMigrateSuccessTemplateId: String = config.get[String]("microservice.services.email.migrateSuccessTemplateId")
-
-  val emailMigrateNotSuccessTemplateId: String =
-    config.get[String]("microservice.services.email.migrateNotSuccessTemplateId")
+  val emailRegisterSuccessTemplateId: String     = config.get[String]("microservice.services.email.registerSuccessTemplateId")
+  val emailRegisterNotSuccessTemplateId: String  = config.get[String]("microservice.services.email.registerNotSuccessTemplateId")
+  val emailSubscribeSuccessTemplateId: String = config.get[String]("microservice.services.email.subscribeSuccessTemplateId")
+  val emailSubscribeNotSuccessTemplateId: String = config.get[String]("microservice.services.email.subscribeNotSuccessTemplateId")
 
   private val taxEnrolmentsBaseUrl: String = servicesConfig.baseUrl("tax-enrolments")
 

--- a/app/uk/gov/hmrc/customs/managesubscription/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/config/AppConfig.scala
@@ -41,10 +41,17 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val emailServiceContext: String = config.get[String]("microservice.services.email.context")
   val emailServiceUrl: String     = s"$emailServiceBaseUrl$emailServiceContext"
 
-  val emailRegisterSuccessTemplateId: String     = config.get[String]("microservice.services.email.registerSuccessTemplateId")
-  val emailRegisterNotSuccessTemplateId: String  = config.get[String]("microservice.services.email.registerNotSuccessTemplateId")
-  val emailSubscribeSuccessTemplateId: String = config.get[String]("microservice.services.email.subscribeSuccessTemplateId")
-  val emailSubscribeNotSuccessTemplateId: String = config.get[String]("microservice.services.email.subscribeNotSuccessTemplateId")
+  val emailRegisterSuccessTemplateId: String =
+    config.get[String]("microservice.services.email.registerSuccessTemplateId")
+
+  val emailRegisterNotSuccessTemplateId: String =
+    config.get[String]("microservice.services.email.registerNotSuccessTemplateId")
+
+  val emailSubscribeSuccessTemplateId: String =
+    config.get[String]("microservice.services.email.subscribeSuccessTemplateId")
+
+  val emailSubscribeNotSuccessTemplateId: String =
+    config.get[String]("microservice.services.email.subscribeNotSuccessTemplateId")
 
   private val taxEnrolmentsBaseUrl: String = servicesConfig.baseUrl("tax-enrolments")
 

--- a/app/uk/gov/hmrc/customs/managesubscription/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/connectors/EmailConnector.scala
@@ -39,7 +39,7 @@ class EmailConnector @Inject() (appConfig: AppConfig, httpClient: HttpClient) {
 
   private def logResponse(templateId: String): Int => Unit = {
     case ACCEPTED | OK => logger.info(s"sendEmail succeeded for template Id: $templateId")
-    case status        => logger.info(s"sendEmail: request is failed with status $status for template Id: $templateId")
+    case status        => logger.warn(s"sendEmail: request is failed with status $status for template Id: $templateId")
   }
 
 }

--- a/app/uk/gov/hmrc/customs/managesubscription/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/connectors/EmailConnector.scala
@@ -33,13 +33,13 @@ class EmailConnector @Inject() (appConfig: AppConfig, httpClient: HttpClient) {
   def sendEmail(email: Email)(implicit hc: HeaderCarrier): Future[HttpResponse] =
     httpClient.doPost[Email](appConfig.emailServiceUrl, email, Seq("Content-Type" -> "application/json")).map {
       response =>
-        logResponse(email.templateId)(response.status)
+        logResponse(email.templateId, response)
         response
     }
 
-  private def logResponse(templateId: String): Int => Unit = {
+  private def logResponse(templateId: String, response: HttpResponse) = response.status match {
     case ACCEPTED | OK => logger.info(s"sendEmail succeeded for template Id: $templateId")
-    case status        => logger.warn(s"sendEmail: request is failed with status $status for template Id: $templateId")
+    case _             => logger.warn(s"sendEmail: request is failed with $response for template Id: $templateId")
   }
 
 }

--- a/app/uk/gov/hmrc/customs/managesubscription/domain/Journey.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/domain/Journey.scala
@@ -16,19 +16,13 @@
 
 package uk.gov.hmrc.customs.managesubscription.domain
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Reads, Writes}
 
-case class RecipientDetails(
-  journey: Journey.Value,
-  service: String,
-  serviceName: String,
-  recipientEmailAddress: String,
-  recipientFullName: String,
-  orgName: Option[String],
-  completionDate: Option[String],
-  languageCode: Option[String] = None
-)
+object Journey extends Enumeration {
 
-object RecipientDetails {
-  implicit val format = Json.format[RecipientDetails]
+  val Register, Subscribe = Value
+
+  implicit val reads: Reads[Journey.Value]   = Reads.enumNameReads(Journey)
+  implicit val writes: Writes[Journey.Value] = Writes.enumNameWrites
+
 }

--- a/app/uk/gov/hmrc/customs/managesubscription/services/EmailService.scala
+++ b/app/uk/gov/hmrc/customs/managesubscription/services/EmailService.scala
@@ -46,7 +46,9 @@ class EmailService @Inject() (appConfig: AppConfig, emailConnector: EmailConnect
   ): Future[HttpResponse] = {
     val email = Email(
       to = List(recipient.recipientEmailAddress),
-      templateId = templateId, // TODO - replace when cy template available if(recipient.languageCode.contains("cy")) s"${templateId}_cy" else templateId,
+      // TODO - replace when cy template available
+//      templateId = if(recipient.languageCode.contains("cy")) s"${templateId}_cy" else templateId,
+      templateId = templateId,
       parameters = Map(
         "recipientName_FullName" -> recipient.recipientFullName,
         "recipientOrgName"       -> recipient.orgName.getOrElse(""),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -169,10 +169,10 @@ microservice {
       host = localhost
       port = 8300
       context = "/hmrc/email"
-      gyeSuccessTemplateId = "customs_registration_successful"
-      gyeNotSuccessTemplateId = "customs_registration_not_successful"
-      migrateSuccessTemplateId = "customs_migrate_successful"
-      migrateNotSuccessTemplateId = "customs_migrate_not_successful"
+      registerSuccessTemplateId = "customs_registration_successful"
+      registerNotSuccessTemplateId = "customs_registration_not_successful"
+      subscribeSuccessTemplateId = "customs_migrate_successful"
+      subscribeNotSuccessTemplateId = "customs_migrate_not_successful"
       force = false
     }
 

--- a/test/unit/services/EmailServiceSpec.scala
+++ b/test/unit/services/EmailServiceSpec.scala
@@ -19,7 +19,7 @@ package unit.services
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import uk.gov.hmrc.customs.managesubscription.connectors.EmailConnector
-import uk.gov.hmrc.customs.managesubscription.domain.{Journey, RecipientDetails, SubscriptionCompleteStatus}
+import uk.gov.hmrc.customs.managesubscription.domain.{Journey, RecipientDetails}
 import uk.gov.hmrc.customs.managesubscription.services.EmailService
 import uk.gov.hmrc.customs.managesubscription.services.dto.Email
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -34,78 +34,88 @@ class EmailServiceSpec extends BaseSpec {
 
   private val mockEmailConnector = mock[EmailConnector]
 
-  private val gyeSuccessTemplateId: String        = "customs_registration_successful"
-  private val gyeNotSuccessTemplateId: String     = "customs_registration_not_successful"
-  private val migrateSuccessTemplateId: String    = "customs_migrate_successful"
-  private val migrateNotSuccessTemplateId: String = "customs_migrate_not_successful"
+  private val registerSuccessTemplateId: String     = "customs_registration_successful"
+  private val registerNotSuccessTemplateId: String  = "customs_registration_not_successful"
+  private val subscribeSuccessTemplateId: String    = "customs_migrate_successful"
+  private val subscribeNotSuccessTemplateId: String = "customs_migrate_not_successful"
 
   private lazy val emailService = new EmailService(appConfig, mockEmailConnector)
 
-  private val gyeRecipientEmailAddress = "john.doe@example.com"
-  private val gyeRecipientFullName     = "John Doe"
-  private val gyeOrgName               = "Test Company Name"
-  private val gyeCompletionDate        = "5 May 2017"
+  private val registerRecipientEmailAddress = "john.doe@example.com"
+  private val registerRecipientFullName     = "John Doe"
+  private val registerOrgName               = "Test Company Name"
+  private val registerServiceName           = "Register Service"
+  private val registerCompletionDate        = "5 May 2017"
 
-  private val gyeRecipientDetails = RecipientDetails(
+  private val registerRecipientDetails = RecipientDetails(
     Journey.Register,
     "ATaR",
-    gyeRecipientEmailAddress,
-    gyeRecipientFullName,
-    Some(gyeOrgName),
-    Some(gyeCompletionDate)
+    registerServiceName,
+    registerRecipientEmailAddress,
+    registerRecipientFullName,
+    Some(registerOrgName),
+    Some(registerCompletionDate),
+    Some("en")
   )
 
-  private val migrateRecipientEmailAddress = "jane.doe@example.com"
-  private val migrateRecipientFullName     = "Jane Doe"
-  private val migrateOrgName               = "Test Company Name 2"
-  private val migrateCompletionDate        = "23 June 2004"
+  private val subscribeRecipientEmailAddress = "jane.doe@example.com"
+  private val subscribeRecipientFullName     = "Jane Doe"
+  private val subscribeOrgName               = "Test Company Name 2"
+  private val subscribeServiceName           = "Subscribe Service"
+  private val subscribeCompletionDate        = "23 June 2004"
 
-  private val migrateRecipientDetails = RecipientDetails(
+  private val subscribeRecipientDetails = RecipientDetails(
     Journey.Subscribe,
     "ATaR",
-    migrateRecipientEmailAddress,
-    migrateRecipientFullName,
-    Some(migrateOrgName),
-    Some(migrateCompletionDate)
+    subscribeServiceName,
+    subscribeRecipientEmailAddress,
+    subscribeRecipientFullName,
+    Some(subscribeOrgName),
+    Some(subscribeCompletionDate),
+    Some("en")
   )
 
-  private val getYourEORISuccessEmail = Email(
-    to = List(gyeRecipientEmailAddress),
-    templateId = gyeSuccessTemplateId,
+  private val registerSuccessEmail = Email(
+    to = List(registerRecipientEmailAddress),
+    templateId = registerSuccessTemplateId,
     parameters = Map(
-      "recipientName_FullName" -> gyeRecipientFullName,
-      "recipientOrgName"       -> gyeOrgName,
-      "completionDate"         -> gyeCompletionDate
+      "recipientName_FullName" -> registerRecipientFullName,
+      "recipientOrgName"       -> registerOrgName,
+      "serviceName"            -> registerServiceName,
+      "completionDate"         -> registerCompletionDate
     )
   )
 
-  private val getYourEORINotSuccessEmail = Email(
-    to = List(gyeRecipientEmailAddress),
-    templateId = gyeNotSuccessTemplateId,
+  private val registerNotSuccessEmail = Email(
+    to = List(registerRecipientEmailAddress),
+    templateId = registerNotSuccessTemplateId,
     parameters = Map(
-      "recipientName_FullName" -> gyeRecipientFullName,
-      "recipientOrgName"       -> gyeOrgName,
-      "completionDate"         -> gyeCompletionDate
+      "recipientName_FullName" -> registerRecipientFullName,
+      "recipientOrgName"       -> registerOrgName,
+      "serviceName"            -> registerServiceName,
+      "completionDate"         -> registerCompletionDate
     )
   )
 
-  private val migrateSuccessEmail = Email(
-    to = List(migrateRecipientEmailAddress),
-    templateId = migrateSuccessTemplateId,
+  private val subscribeSuccessEmail = Email(
+    to = List(subscribeRecipientEmailAddress),
+    templateId = subscribeSuccessTemplateId,
     parameters = Map(
-      "recipientName_FullName" -> migrateRecipientFullName,
-      "recipientOrgName"       -> migrateOrgName,
-      "completionDate"         -> migrateCompletionDate
+      "recipientName_FullName" -> subscribeRecipientFullName,
+      "recipientOrgName"       -> subscribeOrgName,
+      "serviceName"            -> subscribeServiceName,
+      "completionDate"         -> subscribeCompletionDate
     )
   )
 
-  private val migrateNotSuccessEmail = Email(
-    to = List(migrateRecipientEmailAddress),
-    templateId = migrateNotSuccessTemplateId,
+  private val subscribeNotSuccessEmail = Email(
+    to = List(subscribeRecipientEmailAddress),
+    templateId = subscribeNotSuccessTemplateId,
     parameters = Map(
-      "recipientName_FullName" -> migrateRecipientFullName,
-      "recipientOrgName"       -> migrateOrgName,
-      "completionDate"         -> migrateCompletionDate
+      "recipientName_FullName" -> subscribeRecipientFullName,
+      "recipientOrgName"       -> subscribeOrgName,
+      "serviceName"            -> subscribeServiceName,
+      "completionDate"         -> subscribeCompletionDate
     )
   )
 
@@ -119,9 +129,9 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendSuccessEmail(gyeRecipientDetails)
+      emailService.sendSuccessEmail(registerRecipientDetails)
 
-      verify(mockEmailConnector).sendEmail(meq(getYourEORISuccessEmail))(meq(hc))
+      verify(mockEmailConnector).sendEmail(meq(registerSuccessEmail))(meq(hc))
     }
 
     "call emailConnector with proper content for Register not success email" in {
@@ -129,9 +139,9 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendFailureEmail(gyeRecipientDetails)
+      emailService.sendFailureEmail(registerRecipientDetails)
 
-      verify(mockEmailConnector).sendEmail(meq(getYourEORINotSuccessEmail))(meq(hc))
+      verify(mockEmailConnector).sendEmail(meq(registerNotSuccessEmail))(meq(hc))
     }
 
     "call emailConnector with proper content for Subscribe success email" in {
@@ -139,9 +149,9 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendSuccessEmail(migrateRecipientDetails)
+      emailService.sendSuccessEmail(subscribeRecipientDetails)
 
-      verify(mockEmailConnector).sendEmail(meq(migrateSuccessEmail))(meq(hc))
+      verify(mockEmailConnector).sendEmail(meq(subscribeSuccessEmail))(meq(hc))
     }
 
     "call emailConnector with proper content for Subscribe not success email" in {
@@ -149,9 +159,9 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendFailureEmail(migrateRecipientDetails)
+      emailService.sendFailureEmail(subscribeRecipientDetails)
 
-      verify(mockEmailConnector).sendEmail(meq(migrateNotSuccessEmail))(meq(hc))
+      verify(mockEmailConnector).sendEmail(meq(subscribeNotSuccessEmail))(meq(hc))
     }
 
     "propagate error when emailConnector fails on sending email" in {
@@ -160,7 +170,7 @@ class EmailServiceSpec extends BaseSpec {
       )
 
       the[RuntimeException] thrownBy {
-        await(emailService.sendSuccessEmail(gyeRecipientDetails))
+        await(emailService.sendSuccessEmail(registerRecipientDetails))
       } shouldBe emulatedServiceFailure
     }
   }

--- a/test/unit/services/EmailServiceSpec.scala
+++ b/test/unit/services/EmailServiceSpec.scala
@@ -19,7 +19,7 @@ package unit.services
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import uk.gov.hmrc.customs.managesubscription.connectors.EmailConnector
-import uk.gov.hmrc.customs.managesubscription.domain.{RecipientDetails, SubscriptionCompleteStatus}
+import uk.gov.hmrc.customs.managesubscription.domain.{Journey, RecipientDetails, SubscriptionCompleteStatus}
 import uk.gov.hmrc.customs.managesubscription.services.EmailService
 import uk.gov.hmrc.customs.managesubscription.services.dto.Email
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -47,7 +47,7 @@ class EmailServiceSpec extends BaseSpec {
   private val gyeCompletionDate        = "5 May 2017"
 
   private val gyeRecipientDetails = RecipientDetails(
-    "Register",
+    Journey.Register,
     "ATaR",
     gyeRecipientEmailAddress,
     gyeRecipientFullName,
@@ -61,7 +61,7 @@ class EmailServiceSpec extends BaseSpec {
   private val migrateCompletionDate        = "23 June 2004"
 
   private val migrateRecipientDetails = RecipientDetails(
-    "Subscribe",
+    Journey.Subscribe,
     "ATaR",
     migrateRecipientEmailAddress,
     migrateRecipientFullName,
@@ -119,7 +119,7 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendEmail(gyeRecipientDetails, SubscriptionCompleteStatus.SUCCEEDED)
+      emailService.sendSuccessEmail(gyeRecipientDetails)
 
       verify(mockEmailConnector).sendEmail(meq(getYourEORISuccessEmail))(meq(hc))
     }
@@ -129,7 +129,7 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendEmail(gyeRecipientDetails, SubscriptionCompleteStatus.ERROR)
+      emailService.sendFailureEmail(gyeRecipientDetails)
 
       verify(mockEmailConnector).sendEmail(meq(getYourEORINotSuccessEmail))(meq(hc))
     }
@@ -139,7 +139,7 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendEmail(migrateRecipientDetails, SubscriptionCompleteStatus.SUCCEEDED)
+      emailService.sendSuccessEmail(migrateRecipientDetails)
 
       verify(mockEmailConnector).sendEmail(meq(migrateSuccessEmail))(meq(hc))
     }
@@ -149,7 +149,7 @@ class EmailServiceSpec extends BaseSpec {
         Future.successful(HttpResponse(200))
       )
 
-      emailService.sendEmail(migrateRecipientDetails, SubscriptionCompleteStatus.ERROR)
+      emailService.sendFailureEmail(migrateRecipientDetails)
 
       verify(mockEmailConnector).sendEmail(meq(migrateNotSuccessEmail))(meq(hc))
     }
@@ -160,7 +160,7 @@ class EmailServiceSpec extends BaseSpec {
       )
 
       the[RuntimeException] thrownBy {
-        await(emailService.sendEmail(gyeRecipientDetails, SubscriptionCompleteStatus.SUCCEEDED))
+        await(emailService.sendSuccessEmail(gyeRecipientDetails))
       } shouldBe emulatedServiceFailure
     }
   }

--- a/test/unit/services/SubscriptionCompleteBusinessServiceSpec.scala
+++ b/test/unit/services/SubscriptionCompleteBusinessServiceSpec.scala
@@ -52,7 +52,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
   )
 
   private val recipientDetails: RecipientDetails = RecipientDetails(
-    "Subscribe",
+    Journey.Subscribe,
     "ATaR",
     "john.doe@example.com",
     "John Doe",
@@ -88,7 +88,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
   "SubscriptionCompleteBusinessService" should {
     "generate an audit event when subscription completes with a good state" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.SUCCEEDED)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       when(mockDataStoreConnector.storeEmailAddress(any())(any[HeaderCarrier])).thenReturn(
@@ -109,19 +109,19 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
 
     "send success email to recipient on successful SubscriptionComplete" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.SUCCEEDED)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       when(mockDataStoreConnector.storeEmailAddress(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       await(service.onSubscriptionStatus(mockSubscriptionComplete, formBundleId))
-      verify(mockEmailService).sendEmail(recipientDetails, SubscriptionCompleteStatus.SUCCEEDED)(mockHeaderCarrier)
+      verify(mockEmailService).sendSuccessEmail(recipientDetails)(mockHeaderCarrier)
     }
 
     "send data store request on successful SubscriptionComplete and eori number is available" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.SUCCEEDED)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       when(mockDataStoreConnector.storeEmailAddress(any())(any[HeaderCarrier])).thenReturn(
@@ -139,7 +139,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
         Future.successful(RecipientDetailsWithEori(None, recipientDetails, emailVerificationTimestamp, safeId))
       )
       when(mockSubDisplayConnector.callSubscriptionDisplay(any())(any())).thenReturn(Future.successful(None))
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       await(service.onSubscriptionStatus(mockSubscriptionComplete, formBundleId))
@@ -148,7 +148,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
 
     "not send subscription display request when eori number is found in cache" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.SUCCEEDED)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       when(mockDataStoreConnector.storeEmailAddress(any())(any[HeaderCarrier])).thenReturn(
@@ -164,7 +164,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
         Future.successful(RecipientDetailsWithEori(None, recipientDetails, emailVerificationTimestamp, safeId))
       )
       when(mockSubDisplayConnector.callSubscriptionDisplay(any())(any())).thenReturn(Future.successful(None))
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       await(service.onSubscriptionStatus(mockSubscriptionComplete, formBundleId))
@@ -173,14 +173,14 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
 
     "send non-success email to recipient on unsuccessful SubscriptionComplete" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.ERROR)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendFailureEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       when(mockDataStoreConnector.storeEmailAddress(any())(any[HeaderCarrier])).thenReturn(
         Future.successful(HttpResponse(200))
       )
       await(service.onSubscriptionStatus(mockSubscriptionComplete, formBundleId))
-      verify(mockEmailService).sendEmail(recipientDetails, SubscriptionCompleteStatus.ERROR)(mockHeaderCarrier)
+      verify(mockEmailService).sendFailureEmail(recipientDetails)(mockHeaderCarrier)
     }
 
     "Do not send any email to recipient or data store request for EnrolmentError" in {
@@ -206,7 +206,7 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
 
     "propagate error when email service fails" in {
       mockSubscriptionComplete(SubscriptionCompleteStatus.SUCCEEDED)
-      when(mockEmailService.sendEmail(any(), any())(any[HeaderCarrier])).thenReturn(
+      when(mockEmailService.sendSuccessEmail(any())(any[HeaderCarrier])).thenReturn(
         Future.failed(emulatedServiceFailure)
       )
 

--- a/test/unit/services/SubscriptionCompleteBusinessServiceSpec.scala
+++ b/test/unit/services/SubscriptionCompleteBusinessServiceSpec.scala
@@ -54,10 +54,12 @@ class SubscriptionCompleteBusinessServiceSpec extends UnitSpec with MockitoSugar
   private val recipientDetails: RecipientDetails = RecipientDetails(
     Journey.Subscribe,
     "ATaR",
+    "Advance Tariff Rulings",
     "john.doe@example.com",
     "John Doe",
     Some("Test Company Name"),
-    Some("5 May 2017")
+    Some("5 May 2017"),
+    Some("en")
   )
 
   private val transactionName = "eori-common-component-update-status"

--- a/test/unit/services/config/AppConfigSpec.scala
+++ b/test/unit/services/config/AppConfigSpec.scala
@@ -54,19 +54,19 @@ class AppConfigSpec extends BaseSpec {
     }
 
     "have emailGyeSuccessTemplateId defined" in {
-      appConfig.emailGyeSuccessTemplateId shouldBe "customs_registration_successful"
+      appConfig.emailRegisterSuccessTemplateId shouldBe "customs_registration_successful"
     }
 
     "have emailGyeNotSuccessTemplateId defined" in {
-      appConfig.emailGyeNotSuccessTemplateId shouldBe "customs_registration_not_successful"
+      appConfig.emailRegisterNotSuccessTemplateId shouldBe "customs_registration_not_successful"
     }
 
     "have emailMigrateSuccessTemplateId defined" in {
-      appConfig.emailMigrateSuccessTemplateId shouldBe "customs_migrate_successful"
+      appConfig.emailSubscribeSuccessTemplateId shouldBe "customs_migrate_successful"
     }
 
     "have emailMigrateNotSuccessTemplateId defined" in {
-      appConfig.emailMigrateNotSuccessTemplateId shouldBe "customs_migrate_not_successful"
+      appConfig.emailSubscribeNotSuccessTemplateId shouldBe "customs_migrate_not_successful"
     }
 
     "have taxEnrolmentsContext defined" in {

--- a/test/util/TestData.scala
+++ b/test/util/TestData.scala
@@ -44,12 +44,14 @@ object TestData {
 
   val Register       = Journey.Register
   val Service        = "ATaR"
+  val ServiceName    = "Advance Tariff Rulings"
   val FullName       = "Full Name"
   val Email          = "john.doe@digital.hmrc.gov.uk"
   val OrgName        = "Test Company Name"
   val CompletionDate = "5 May 2017"
 
-  val recipientDetails = RecipientDetails(Register, Service, Email, FullName, Some(OrgName), Some(CompletionDate))
+  val recipientDetails =
+    RecipientDetails(Register, Service, ServiceName, Email, FullName, Some(OrgName), Some(CompletionDate), None)
 
   val NoHeaders: Map[String, String] = Map[String, String]()
 
@@ -118,6 +120,7 @@ object TestData {
         |	"recipientDetails": {
         |   "journey": "$Register",
         |   "service": "$Service",
+        |   "serviceName": "$ServiceName",
         |   "recipientFullName": "$FullName",
         |	  "recipientEmailAddress": "$Email",
         |   "orgName": "$OrgName",

--- a/test/util/TestData.scala
+++ b/test/util/TestData.scala
@@ -42,14 +42,14 @@ object TestData {
   val MdtpBearerToken: String = "Bearer ValidBearerToken"
   val AcceptHmrcJson: String  = "application/vnd.hmrc.1.0+xml"
 
-  val Journey        = "Register"
+  val Register       = Journey.Register
   val Service        = "ATaR"
   val FullName       = "Full Name"
   val Email          = "john.doe@digital.hmrc.gov.uk"
   val OrgName        = "Test Company Name"
   val CompletionDate = "5 May 2017"
 
-  val recipientDetails = RecipientDetails(Journey, Service, Email, FullName, Some(OrgName), Some(CompletionDate))
+  val recipientDetails = RecipientDetails(Register, Service, Email, FullName, Some(OrgName), Some(CompletionDate))
 
   val NoHeaders: Map[String, String] = Map[String, String]()
 
@@ -116,7 +116,7 @@ object TestData {
         |{
         |	"formBundleId": "$formBundleId",
         |	"recipientDetails": {
-        |   "journey": "$Journey",
+        |   "journey": "$Register",
         |   "service": "$Service",
         |   "recipientFullName": "$FullName",
         |	  "recipientEmailAddress": "$Email",


### PR DESCRIPTION
This PR is the prep work required to support the new email templates
- add support for "friendly" service name
- add support for Welsh emails

I've refactored the config keys for the email templates but not the values yet as the new templates still need to be approved and deployed.  So with these changes the service will continue to send the "old" CDS emails.

TODO
- update email template ids when they are available
- un-comment the TODO when Welsh templates available